### PR TITLE
updated reference: lhs for += and friends is only evaluated once

### DIFF
--- a/documentation/reference/operator/add-assign.md
+++ b/documentation/reference/operator/add-assign.md
@@ -21,27 +21,13 @@ by the amount given by its right-hand operand.
 ## Description
 
 
-### Side effects
-
-In the process of performing an add & assign the left-hand argument 
-may be evaluated *more than once*, in contrast to how this operator is defined
-in some other languages. This doesn't usually cause problems, but if evaluating
-the left-hand operand has side-effects it could result in unexpected behaviour,
-as an example consider:
-
-    void m(Natural[] seq, Natural index) {
-        seq[index++] += 1;
-    }
-
-The above code doesn't increment the `index`<sup>th</sup> element of `seq`, as it 
-may appear, it instead adds one to the `index`<sup>th</sup> element and 
-assigns the result to the (`index+1`)<sup>th</sup> element.
-
 ### Definition
 
 The operator is defined as: 
 
     lhs:=lhs.plus(rhs.castTo<N>())
+
+except that `lhs` is evaluated only once.
 
 See the [language specification](#{site.urls.spec}#arithmetic) for more details.
 

--- a/documentation/reference/operator/divide-assign.md
+++ b/documentation/reference/operator/divide-assign.md
@@ -19,27 +19,14 @@ the amount given by its right-hand operand.
 
 ## Description
 
-### Side effects
-
-In the process of performing a divide & assign the left-hand argument 
-may be evaluated *more than once*, in contrast to how this operator is defined
-in some other languages. This doesn't usually cause problems, but if evaluating
-the left-hand operand has side-effects it could result in unexpected behaviour,
-as an example consider:
-
-    void m(Float[] seq, Natural index) {
-        seq[index++] /= 2.0;
-    }
-
-The above code doesn't half the `index`<sup>th</sup> element of `seq`, as it 
-may appear, it instead halves the `index`<sup>th</sup> element and 
-assigns the result to the (`index+1`)<sup>th</sup> element.
 
 ### Definition
 
 The `/=` operator is defined as follows
 
     lhs:=lhs.divided(rhs.castTo<N>())
+
+except that `lhs` is evaluated only once.
 
 See the [language specification](#{site.urls.spec}#arithmetic) for more details.
 

--- a/documentation/reference/operator/multiply-assign.md
+++ b/documentation/reference/operator/multiply-assign.md
@@ -21,27 +21,14 @@ left-hand operand.
 
 ## Description
 
-### Side effects
-
-In the process of performing a multiply & assign the left-hand argument 
-may be evaluated *more than once*, in contrast to how this operator is defined
-in some other languages. This doesn't usually cause problems, but if evaluating
-the left-hand operand has side-effects it could result in unexpected behaviour,
-as an example consider:
-
-    void m(Natural[] seq, Natural index) {
-        seq[index++] *= 2;
-    }
-
-The above code doesn't double the `index`<sup>th</sup> element of `seq`, as it 
-may appear, it instead doubles the `index`<sup>th</sup> element and 
-assigns the result to the (`index+1`)<sup>th</sup> element.
 
 ### Definition
 
 The `*=` operator is defined as follows:
 
     lhs:=lhs.times(rhs.castTo<N>())
+
+except that `lhs` is evaluated only once.
 
 See the [language specification](#{site.urls.spec}#arithmetic) for more details.
 

--- a/documentation/reference/operator/remainder-assign.md
+++ b/documentation/reference/operator/remainder-assign.md
@@ -20,29 +20,14 @@ the left-hand operand with the result.
 
 ## Description
 
-### Side effects
-
-In the process of performing a remainder & assign the left-hand argument 
-may be evaluated *more than once*, in contrast to how this operator is defined
-in some other languages. This doesn't usually cause problems, but if evaluating
-the left-hand operand has side-effects it could result in unexpected behaviour,
-as an example consider:
-
-    void m(Natural[] seq, Natural index) {
-        seq[index++] %= 2;
-    }
-
-The above code doesn't put the remainder of a division by two in the 
-`index`<sup>th</sup> element of `seq`, as it 
-may appear, it instead calculates the remainder with respect to 
-the `index`<sup>th</sup> element and 
-assigns the result to the (`index+1`)<sup>th</sup> element.
 
 ### Definition
 
 The `%=` operator is defined as follows:
 
     lhs:=lhs.remainder(rhs.castTo<N>())
+
+except that `lhs` is evaluated only once.
 
 See the [language specification](#{site.urls.spec}#arithmetic) for more details.
 

--- a/documentation/reference/operator/subtract-assign.md
+++ b/documentation/reference/operator/subtract-assign.md
@@ -20,27 +20,14 @@ by the amount given by its right-hand operand.
 
 ## Description
 
-### Side effects
-
-In the process of performing a subtract & assign the left-hand argument 
-may be evaluated *more than once*, in contrast to how this operator is defined
-in some other languages. This doesn't usually cause problems, but if evaluating
-the left-hand operand has side-effects it could result in unexpected behaviour,
-as an example consider:
-
-    void m(Natural[] seq, Natural index) {
-        seq[index++] -= 1;
-    }
-
-The above code doesn't decrement the `index`<sup>th</sup> element of `seq`, as 
-it may appear, it instead subtracts one from the `index`<sup>th</sup> element and 
-assigns the result to the (`index+1`)<sup>th</sup> element.
 
 ### Definition 
 
 The `-=` operator is defined as follows:
 
     lhs:=lhs.minus(rhs.castTo<N>())
+
+except that `lhs` is evaluated only once.
 
 See the [language specification](#{site.urls.spec}#arithmetic) for more details.
 


### PR DESCRIPTION
Making clear that Ceylon is _not_ evil by removing outdated statements about side-effects from some reference pages.
