### PR TITLE
Have code example use generic type that is actually defined in the code ...

### DIFF
--- a/documentation/1.0/tour/generics.md
+++ b/documentation/1.0/tour/generics.md
@@ -248,7 +248,7 @@ constraint, an *upper bound*.
         ...
      
         shared Boolean contains(Object obj) {
-            if (is T obj) {
+            if (is Element obj) {
                 return obj in bucket(obj.hash);
             }
             else {


### PR DESCRIPTION
...(i.e. Element) instead of one that is not previously defined (i.e. T).

The example is a little outdated as `Set.contains()` is inherited from `Collection` and it is no longer defined like that, but the code still gets the point across.
