### PR TITLE
Simplify example

### DIFF
--- a/documentation/1.0/tour/sequences.md
+++ b/documentation/1.0/tour/sequences.md
@@ -143,7 +143,7 @@ iterating [`Entry`s](#{site.urls.apidoc_current}/ceylon/language/class_Entry.htm
 -->
 <!-- cat: void m(String operators) { -->
     for (i -> op in entries(operators...)) {
-        print("" i.string ": " op "");
+        print("" i ": " op "");
     }
 <!-- cat: } -->
 


### PR DESCRIPTION
Since we are using a string template, there is no need to convert the index to string
