### PR TITLE
Fix colon not displaying correctly in title

### DIFF
--- a/_ext/pipeline.rb
+++ b/_ext/pipeline.rb
@@ -73,6 +73,9 @@ Awestruct::Extensions::Pipeline.new do
     /<pre><code>(.*?)<\/code><\/pre>/, 
     "<pre class=\"brush: ceylon\">\\1</pre>")
   transformer Awestruct::Extensions::Gsub.new(
+    /\<title\>(.*?)\&amp\;\#58\;(.*?)\<\/title\>/,
+    "<title>\\1:\\2</title>")
+  transformer Awestruct::Extensions::Gsub.new(
     /\<!--\s*m1\s*--\>\s*/, 
     "<span class='milestone'><a href='/documentation/1.0/roadmap/#milestone_1_done' title='Support for this feature was introduced in Milestone 1'>Milestone 1</a></span>")
   transformer Awestruct::Extensions::Gsub.new(


### PR DESCRIPTION
The tour's title format uses semicolon which breaks the parsing
of the generator. To avoid this we escape the colon which in turn
leads to it not being displayed correctly in title as it's not
rendered by the browser.

Replace the escaped colon for the title via regex. A better and
long term solution is to patch the generator, yet this solution is
good enough for the time being without touching any dependency.
