### PR TITLE
Set CEYLON_HOME correctly for bootstrap build

### DIFF
--- a/code/contribute.md
+++ b/code/contribute.md
@@ -22,6 +22,8 @@ author: Stephane Epardaud
 <!-- lang: bash -->
     $ cd ceylon-dist ; ant setup
 
+- Set the environment variable `CEYLON_HOME` to the full path of the (not yet existing) subdirectory `dist` within `ceylon-dist`.
+
 - Now to build the complete distribution run
 
 <!-- lang: bash -->


### PR DESCRIPTION
Fixed the problem for new developers, who will get `ceylon.language/build.xml:189: Error running Ceylon compile tool (an exception was thrown, run ant with -v parameter to see the exception)`, because `<ceylon-compile>` cannot find the correct `ceylon` command.
