### PR TITLE
markdown.md: Remove "may be revised before 1.0" notice

### DIFF
--- a/documentation/1.0/reference/annotation/markdown.md
+++ b/documentation/1.0/reference/annotation/markdown.md
@@ -88,8 +88,6 @@ Unsupported syntaxes are not highlighted at all.
 
 ### Wiki-style links
 
-**Note: Some of aspects of Wiki-style links may be revised before 1.0**
-
 As an extension to the basic Markdown syntax, `ceylon doc` supports 
 "Wiki-style" links for linking to the documentation of other declarations. 
 These links are enclosed within double square brackets,


### PR DESCRIPTION
1.0 is out, so nothing will be revised before 1.0 anymore :)

Are there still planned changes? In that case, you should of course discard this commit and instead _edit_ that notice.
