### PR TITLE
test-plugin doc: single quotes to double quotes

### DIFF
--- a/documentation/1.0/ide/test-plugin.md
+++ b/documentation/1.0/ide/test-plugin.md
@@ -20,8 +20,8 @@ The test framework is in the Ceylon SDK module `ceylon.test`, latest version and
 So let’s start by importing the `ceylon.test` module in our module descriptor and writing our first test.
 
 <!-- try: -->
-    module com.acme.foo '1.0.0' {
-        import ceylon.test '1.0.0';
+    module com.acme.foo "1.0.0" {
+        import ceylon.test "1.0.0";
     }
 
 


### PR DESCRIPTION
Single quotes in module descriptors are no longer valid, see ceylon/ceylon-spec#723 and ceylon/ceylon-runtime#47.

I’m pretty sure these are the only remaining single quotes in this repository.
