### PR TITLE
Don’t show pointer cursor on non-clickable elements

### DIFF
--- a/stylesheets/screen.scss
+++ b/stylesheets/screen.scss
@@ -199,9 +199,6 @@ form.bp {
       margin:0;
       list-style-type: none;
       float: right;
-      li:hover {
-        cursor:pointer;
-      }
       
       li {
         margin-top: 0;


### PR DESCRIPTION
This changes the cursor for the navigation bar. Before this change, the cursor changes to “pointer”, which normally indicates an element with a click action, as soon as you hover over a navigation “tab”, even when you’re not hovering over the link. This means that you get the “pointer” cursor in locations where clicking won’t actually do anything, which is confusing to the user, and annoying once they figure it out.

Fixed by completely removing the custom cursor. For the link, the browser will use the “pointer” cursor anyways.

You can verify this by going to [ceylon-lang.org](http://ceylon-lang.org/), moving the mouse over e. g. the “Blog” link, and then moving it to the left until it’s no longer over the text. Notice how the cursor is still “pointer” (i. e., on most systems, a “hand”), but clicking won’t do anything.

Tested by editing the stylesheet with Firefox’ web developer tools. The stylesheet is minified, but you can simply search for `li:hover`, and remove the first occurence, to test the change yourself.
