### PR TITLE
Fixed or removed about 25 broken links

### DIFF
--- a/documentation/1.0/reference/operator/intersect-assign.md
+++ b/documentation/1.0/reference/operator/intersect-assign.md
@@ -37,7 +37,7 @@ more details.
 
 The `&=` operator is [polymorphic](#{page.doc_root}/reference/operator/operator-polymorphism). 
 
-The `&` in the definition is the [intersect operator](../intersect) which 
+The `&` in the definition is the [intersect operator](../intersection) which 
 depends on the [`Set`](#{site.urls.apidoc_current}/Set.type.html) interface.
 
 ### Type

--- a/documentation/1.0/reference/operator/lookup.md
+++ b/documentation/1.0/reference/operator/lookup.md
@@ -50,8 +50,6 @@ The result type of the `lhs[index]` operator is the element type of the `Corresp
 
 ## See also
 
-* [`?[]` (nullsafe lookup)](../nullsafe-lookup) operator used for accessesing 
-  a `Correspondence?`
 * API documentation for [`Correspondence`](#{site.urls.apidoc_current}/Correspondence.type.html) 
 * [sequence operators](#{site.urls.spec_current}#listmap) in the 
   language specification

--- a/documentation/1.0/reference/repository/modules.ceylon-lang.org.md
+++ b/documentation/1.0/reference/repository/modules.ceylon-lang.org.md
@@ -37,5 +37,5 @@ to run your own instance, just as powerful as what we're using, and contribute t
 
 ## See also
 
-* [Module repositories](../repository).
+* [Module repositories](..).
 

--- a/documentation/1.0/reference/statement/conditions.md
+++ b/documentation/1.0/reference/statement/conditions.md
@@ -19,8 +19,7 @@ in the `if`, `while`, and `assert` statements and in `if` comprehension clauses.
 ## Usage
 
 A condition list may occur in an [`if`](../if), [`while`](../while), or 
-[`assert`](../assert) statements, or in an `if` clause of a
-[comprehension](../../expression/comprehension).
+[`assert`](../assert) statements, or in an `if` clause of a comprehension.
 
 ## Description
 

--- a/documentation/1.0/reference/statement/try.md
+++ b/documentation/1.0/reference/statement/try.md
@@ -47,14 +47,14 @@ The `try` clause may optionally have a list of one or more
 *resource expressions*. If it does then both `catch` and `finally` clauses 
 are optional, otherwise at least one other of those clauses is required.
 
-The [`catch` clause](../catch) specifies the [type](../../structure/type) 
+The `catch` clause specifies the [type](../../structure/type) 
 of exception (which must be a subtype of 
 [`Exception`](#{site.urls.apidoc_current}/Exception.type.html)) to be handled 
 by the associated block. The block is executed only if an exception 
 assignable to that type propagates out of the `try` block and the exception 
 was not assignable to the type of any earlier `catch` clause.
 
-The [`finally` clause](../finally) specifies a block to be executed whether 
+The `finally` clause specifies a block to be executed whether 
 or not an exception propogated out of the `try` block, and whether or not any 
 matching `catch` clause was found.
 

--- a/documentation/1.0/reference/structure/compilation-unit.md
+++ b/documentation/1.0/reference/structure/compilation-unit.md
@@ -44,8 +44,8 @@ A compilation unit may contain one or more declarations:
 
 * [type declarations](../type) ([class](../class), 
   [interface](../interface), or [`object`](../object)), 
-* [function declarations](../method), and/or
-* [value declarations](../attribute).
+* [function declarations](../function), and/or
+* [value declarations](../value).
 
 [Module descriptors](../module/#descriptor) and 
 [package descriptors](../package/#descriptor) are special-purpose 

--- a/documentation/1.0/reference/structure/function.md
+++ b/documentation/1.0/reference/structure/function.md
@@ -35,7 +35,7 @@ Alternatively it's possible to declare a function using
 
 Method invocations have a 'receiver', an instance of the type that declares 
 the method. Within the method [body](#method_blocks), the expression 
-[`this`](../../expression/self-reference) refers to this receiving instance.
+[`this`](../../expression/this) refers to this receiving instance.
 
 A [top level](../type#top_level_declarations) function does not have a 
 receiver. 

--- a/documentation/1.0/reference/structure/interface.md
+++ b/documentation/1.0/reference/structure/interface.md
@@ -100,8 +100,8 @@ inside the body of a containing class or interface, may be annotated
 ### Members
 
 The permitted members of interfaces are [classes](../class), 
-[interfaces](../interface), [methods](../method), and 
-[attributes](../attribute).
+[interfaces](../interface), [methods](../function), and 
+[attributes](../value).
 
 Note that an interface cannot have an [`object`](../object) member.
 

--- a/documentation/1.0/reference/structure/keyword.md
+++ b/documentation/1.0/reference/structure/keyword.md
@@ -24,7 +24,7 @@ The following are reserved keywords:
 * `abstracts` (currently unused)
 * [`alias`](../alias#type_alises)
 * [`assert`](../../statement/assert)
-* [`assign`](../attribute#attribute_setters)
+* [`assign`](../value#a_value_setter)
 * [`break`](../../statement/break)
 * [`case`](../../statement/switch)
 * [`catch`](../../statement/try)
@@ -77,7 +77,7 @@ The following are reserved keywords:
 * [`throw`](../../statement/throw)
 * [`try`](../../statement/try)
 * [`value`](../type-inference)
-* [`void`](../method#return_type)
+* [`void`](../function#return_type)
 * [`while`](../../statement/while)
 
 

--- a/documentation/1.0/reference/structure/object.md
+++ b/documentation/1.0/reference/structure/object.md
@@ -9,7 +9,7 @@ author: Tom Bentley
 # #{page.title_md}
 
 An `object` declaration is an anonymous [class](../class) that is 
-implicitly [instantiated](../../expression/class-instantiation)
+implicitly instantiated
 exactly once at the place it is defined, and nowhere else. As such it 
 is also a [value](../value).
 
@@ -73,7 +73,7 @@ The instance is a [value](../value), so can be manipulated
 ### Members
 
 The permitted members of `object`s are [classes](../class), 
-[interfaces](../interface), [methods](../method), [attributes](../attribute),
+[interfaces](../interface), [methods](../function), [attributes](../value),
 and [`object`s](../object).
 
 ## See also

--- a/documentation/1.0/reference/structure/parameter-list.md
+++ b/documentation/1.0/reference/structure/parameter-list.md
@@ -162,7 +162,7 @@ an anonymous function:
 ## See also
 
 * [Type parameters](../type-parameters)
-* [`class` declaration](../../type/class)
+* [`class` declaration](../class)
 * [`function` declaration](../function/) 
 * [Parameters](#{site.urls.spec_current}#parameters) in the Ceylon 
   language spec

--- a/documentation/1.0/reference/structure/type-parameters.md
+++ b/documentation/1.0/reference/structure/type-parameters.md
@@ -170,8 +170,8 @@ for `PossiblyEmpty<T>` and `NonEmpty<T>`, the type abbreviations `{T*}` and
 
 ## See also
 
-* [`class` declaration](../../type/class)
-* [`interface` declaration](../../type/interface)
+* [`class` declaration](../class)
+* [`interface` declaration](../interface)
 * [`function` declaration](../function/)
 * [Generic type parameters](#{site.urls.spec_current}#generictypeparameters) 
   in the Ceylon language spec

--- a/documentation/1.0/reference/structure/type.md
+++ b/documentation/1.0/reference/structure/type.md
@@ -50,7 +50,7 @@ In Ceylon, a *type declaration* is one of:
 * An [`object` declaration](../object)
 * An [`interface` declaration](../interface)
 
-A [type parameter](../type-parameter) is also sometimes considered a
+A [type parameter](../type-parameters) is also sometimes considered a
 kind of type declaration. However, a type parameter may not declare
 members.
 
@@ -146,7 +146,7 @@ of the [expression `[]`](../../expression/sequence-instantiation).
 ### `Sequence`
 
 [`Sequence`](#{site.urls.apidoc_current}/Sequence.type.html) is the 
-type of non-empty [sequences](../../expression/sequence-instantiation).
+type of non-empty sequences.
 `Sequence<T>` is usually abbreviated to `[T+]`.
 
 ### `Tuple`

--- a/documentation/1.0/reference/structure/value.md
+++ b/documentation/1.0/reference/structure/value.md
@@ -99,7 +99,7 @@ setter declaration.
 
 Attribute evaluations have a 'receiver', an instance of the type that 
 declares the method. Within the getter or setter body, the expression 
-[`this`](../../expression/self-reference) refers to this receiving 
+[`this`](../../expression/this) refers to this receiving 
 instance.
 
 A [top level](../type#top_level_declarations) value does not have a 


### PR DESCRIPTION
Information about the links that were removed because I could not find a replacement :
- removed links to comprehension page as the comprehension page does not exist anymore in the reference doc.
- removed links to nullsafe-lookup  (actually completely removed the text about nullsafe-lookup)
- removed links to catch and finally that do not exists anymore in the reference doc.
- removed links to class-instantiation that does not exists anymore in the reference doc.
