### PR TITLE
Fix remaining broken links in /reference/

### DIFF
--- a/documentation/1.0/reference/operator/intersect-assign.md
+++ b/documentation/1.0/reference/operator/intersect-assign.md
@@ -37,7 +37,7 @@ more details.
 
 The `&=` operator is [polymorphic](#{page.doc_root}/reference/operator/operator-polymorphism). 
 
-The `&` in the definition is the [intersect operator](../intersection) which 
+The `&` in the definition is the [intersection operator](../intersection) which 
 depends on the [`Set`](#{site.urls.apidoc_current}/Set.type.html) interface.
 
 ### Type
@@ -47,7 +47,7 @@ the left hand operand's element type.
 
 ## See also
 
-* [`&` (intersect)](../intersect) operator
+* [`&` (intersection)](../intersection) operator
 * API documentation for [`Set`](#{site.urls.apidoc_current}/Set.type.html)
 * [set operators](#{site.urls.spec_current}#sets) in the 
   language specification

--- a/documentation/1.0/reference/operator/invoke.md
+++ b/documentation/1.0/reference/operator/invoke.md
@@ -44,7 +44,6 @@ The result type of the invocation operator expressions is the return type of the
 
 ## See also
 
-* [null-safe version](../nullsafe-invoke) of invoke.
 * [spread invoke] _doc coming soon at_ (../spread-invoke) for calling a `Callable[]`
 * API documentation for [`Callable`] _doc coming soon at_ (../../ceylon.language/Callable)
 * [operator precedence](#{site.urls.spec_current}#operatorprecedence) in the 

--- a/documentation/1.0/reference/structure/class.md
+++ b/documentation/1.0/reference/structure/class.md
@@ -13,8 +13,7 @@ A class is a stateful type that:
 
 - may hold references to other objects,
 - may define initialization logic and initialization parameters, and
-- except in the case of an `abstract` class, may be 
-  [instantiated](../../expression/class-instantiation).
+- except in the case of an `abstract` class, may be instantiated.
 
 A class may inherit another class, but classes are restricted to a
 _single inheritance_ model. That is, a class inherits exactly _one_
@@ -37,7 +36,7 @@ A trivial class declaration looks like this:
 ### Initializer
 
 The class *initializer* executes when instances of the class are created
-(also known as [*class instantiation*](../../expression/class-instantiation)). 
+(also known as *class instantiation*). 
 The parameters to the initializer are specified in parenthesis after the 
 name of the class in the `class` declaration.
 
@@ -137,7 +136,7 @@ is `Example(Integer, Boolean)`.
 
 ### Concrete classes
 
-A class that can be [instantiated](../../expression/class-instantiation) is 
+A class that can be instantiated is 
 *concrete*. It follows that `abstract` or `formal` classes are not concrete.
 
 ### Abstract classes
@@ -186,7 +185,7 @@ may be annotated [`formal`](../../annotation/formal). A formal class must
 also be annotated `shared`.
 
 Like abstract classes, formal classes may have formal members. Unlike abstract
-classes, formal classes may be [instantiated](../../expression/class-instantiation).
+classes, formal classes may be instantiated.
 
 A `formal` class must be [refined](#member_class_refinement) by concrete 
 subclasses of the containing class or interface. 

--- a/documentation/1.0/reference/structure/interface.md
+++ b/documentation/1.0/reference/structure/interface.md
@@ -12,7 +12,7 @@ An interface is a stateless type that, unlike a [class](../class):
 
 - may not hold references to other objects,
 - does not define initialization logic, and 
-- cannot be directly [instantiated](../../expression/class-instantiation).
+- cannot be directly instantiated.
 
 Interfaces support a more flexible inheritance model: _multiple inheritance_.
 "Diamond" inheritance is not a problem for interfaces, because interfaces 

--- a/documentation/1.0/reference/structure/type.md
+++ b/documentation/1.0/reference/structure/type.md
@@ -141,7 +141,7 @@ is an enumerated type with subtypes
 ### `Empty`
 
 [`Empty`](#{site.urls.apidoc_current}/Empty.type.html) is the type 
-of the [expression `[]`](../../expression/sequence-instantiation). 
+of the expression `[]`. 
 
 ### `Sequence`
 


### PR DESCRIPTION
More fix related to missing _class-instantiation_,  _nullsafe-invoke_, _sequence-instantiation_ and misc
I think that in /reference/ I'm done now :)
