### PR TITLE
Introduction: Fix type (Sequential -> Iterable)

### DIFF
--- a/documentation/1.0/introduction.md
+++ b/documentation/1.0/introduction.md
@@ -553,8 +553,8 @@ It's even possible to pass a member method or attribute reference to a
 higher-order function:
 
 <!-- try: -->
-    String[] names = { "Gavin", "Stef", "Tom", "Tako" };
-    String[] uppercaseNames = names.map(String.uppercased);
+    {String*} names = { "Gavin", "Stef", "Tom", "Tako" };
+    {String*} uppercaseNames = names.map(String.uppercased);
 
 Unlike other statically-typed languages with higher-order functions, Ceylon
 has a single function type, the interface `Callable`. There's no need to


### PR DESCRIPTION
The other way to fix this would be:

``` diff
-    String[] names = { "Gavin", "Stef", "Tom", "Tako" };
-    String[] uppercaseNames = names.map(String.uppercased);
+    String[] names = [ "Gavin", "Stef", "Tom", "Tako" ];
+    String[] uppercaseNames = names.collect(String.uppercased);
```

But this requires the less familiar function `collect` instead of `map`; in my opinion, the `{String*}` syntax is the lesser evil.
