### PR TITLE
minor typo in Tour

### DIFF
--- a/documentation/1.0/tour/basics.md
+++ b/documentation/1.0/tour/basics.md
@@ -542,7 +542,7 @@ mean a value which is explicitly defined to be reassignable.
     String bye = "Adios";        //a value
     variable Integer count = 0;  //a variable
     
-    bye = "Adeu";  //compile error
+    bye = "Adieu";  //compile error
     count = 1;     //allowed
 
 Note that even a value which isn't a variable in this sense, may still be


### PR DESCRIPTION
Purely cosmetic :
In the example I guess that _Adeu_ was stop supposed to be _Adieu_ in French (that is, _Adios_ or _Bye_)
