### PR TITLE
Update ant-ceylon-copy.md

### DIFF
--- a/documentation/1.1/reference/tool/ant-ceylon-copy.md
+++ b/documentation/1.1/reference/tool/ant-ceylon-copy.md
@@ -20,12 +20,12 @@ to a module repository in the `build` directory:
     <target name="copy" depends="ceylon-ant-taskdefs">
       <ceylon-copy out="build" recursive="true">
         <module name="com.example.foo" version="1.5"/>
-      </ceylon-compile>
+      </ceylon-copy>
     </target>
 
 ## Description
 
-The `<ceylon-compile>` ant task supports copying a module or a set of
+The `<ceylon-copy>` ant task supports copying a module or a set of
 modules from one repository to another. It can also copy all the module's
 dependencies and their dependencies until the entire module tree has been copied.
 


### PR DESCRIPTION
Fix two more "compile" instead of "copy" that I missed in f5dffea / #325. Dangit :/

CC @gavinking / @quintesse.

Also note that the website hasn’t updated itself after #325 ([here](http://ceylon-lang.org/documentation/1.1/reference/tool/ant-ceylon-copy/)).
