### PR TITLE
Fix markdown in contribute page

### DIFF
--- a/code/contribute.md
+++ b/code/contribute.md
@@ -20,19 +20,19 @@ And now you either set things up for HTTPS access (recommended for most people):
 <!-- lang: bash -->
     $ git clone https://github.com/ceylon/ceylon-dist.git
 	
-( If you encounter issue like fatal: "unable to access 'https://github.com/ceylon/ceylon-dist.git/': 
-	Failed connect to github.com:443; No error", make sure you've set up your proxy as git config, ie: 
+(If you encounter an issue like "fatal: unable to access 'https://github.com/ceylon/ceylon-dist.git/': 
+Failed connect to github.com:443; No error", make sure you've set up your proxy as git config, ie: 
 <!-- lang: bash -->
 	$ git config --global http.proxy http://userName:password@proxyServer:port 
 
-that should fix it )
+that should fix it.)
 	
 - Go into the newly created ceylon-dist directory and run the setup
 
 <!-- lang: bash -->
     $ cd ceylon-dist ; ant setup
 
-Or you set things up for SSH access (mainly contributers with push access):
+Or you set things up for SSH access (mainly contributors with push access):
 
 - Make sure you have [GitHub SSH access set up correctly](https://help.github.com/articles/generating-ssh-keys)
 - Clone ceylon-dist:


### PR DESCRIPTION
The markdown renderer was interpreting the tab as the start of a code span.

This is visible on the [live page](http://ceylon-lang.org/code/contribute/), but not on the [Github version](https://github.com/ceylon/ceylon-lang.org/blob/b46a0213b117679e4f3b9af402082a06a461e65e/code/contribute.md), because they use different markdown renderers.

CC #289.

Also fixes some other very minor things.
