### PR TITLE
Clarify fictitious imported module

### DIFF
--- a/documentation/1.3/reference/statement/import.md
+++ b/documentation/1.3/reference/statement/import.md
@@ -25,11 +25,11 @@ declarations belonging to that package, with an optional wildcard:
 <!-- check:none -->
 <!-- try: -->
     // importing a list of declarations
-    import math { sqrt, pi, Complex }
+    import org.example.math { sqrt, pi, Complex }
     
     // importing all declarations in a package
     // (a 'wildcard' import)
-    import com.example.metasyntax { ... }
+    import org.example.metasyntax { ... }
     
     // assigning a different name to an imported declaration
     // (an 'alias' import)
@@ -83,7 +83,7 @@ _import alias_.
 
 ### Advice
 
-Use of wildcard `import`s (e.g. `import com.example.metasyntax { ... }`) 
+Use of wildcard `import`s (e.g. `import org.example.metasyntax { ... }`) 
 is discouraged, since:
 
 * when reading, it makes it harder to determine which package a particular 


### PR DESCRIPTION
@drhagen pointed out [on StackOverflow][1] that a module containing a `math` package is nowhere to be found. I assume it’s intended to be fictitious (the `ceylon.math` in the SDK lacks `Complex`), so add `org.example` to the package name to clarify this and bring the import in line with the other imports below.

Also, while we’re at it, consistently use `org.example` instead of `com.example`.

[1]: https://stackoverflow.com/q/49592547/1420237