### PR TITLE
add missing new keyword

### DIFF
--- a/documentation/1.3/reference/structure/class.md
+++ b/documentation/1.3/reference/structure/class.md
@@ -342,7 +342,7 @@ Alternatively the constructor can delegate to another
 constructor of the *same* class:
 
     class SelfDelegation {
-        shared greet(String greeting, String subject) {
+        shared new greet(String greeting, String subject) {
         }
         shared new hello(String subject) extends greet("hello", subject) {
         }


### PR DESCRIPTION
As proven by the "try it online" link under this snippet, without this we don't get a constructor – we don't even get a valid method definition here.